### PR TITLE
DS-3164 Item statistic displays UUID of bitstreams instead of name

### DIFF
--- a/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
+++ b/dspace-api/src/main/java/org/dspace/statistics/content/StatisticsDataVisits.java
@@ -511,7 +511,7 @@ public class StatisticsDataVisits extends StatisticsData
                         {
                             break;
                         }
-                        return value;
+                        return bit.getName();
                     case Constants.ITEM:
                         Item item = itemService.findByIdOrLegacyId(context, dsoId);
                         if(item == null)


### PR DESCRIPTION
Fix this bug.